### PR TITLE
Suporte múltiplas URLs em BOT_URL (vírgula separada)

### DIFF
--- a/keepalive.js
+++ b/keepalive.js
@@ -6,16 +6,30 @@ require('dotenv').config();
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-// Configuração dos serviços a monitorar
-const SERVICES = [
-    {
-        name: 'WhatsApp Bot',
-        url: process.env.BOT_URL,
+// Gera serviços dinamicamente a partir da variável BOT_URL
+// Suporta múltiplas URLs separadas por vírgula
+const generateServices = () => {
+    const botUrls = process.env.BOT_URL || '';
+    
+    // Se não houver URL configurada, retorna array vazio
+    if (!botUrls.trim()) {
+        return [];
+    }
+    
+    // Divide por vírgula e remove espaços em branco
+    const urls = botUrls.split(',').map(url => url.trim()).filter(url => url);
+    
+    // Gera um serviço para cada URL
+    return urls.map((url, index) => ({
+        name: `Service ${index + 1}`,
+        url: url,
         interval: '*/12 * * * *', // A cada 12 minutos
         timeout: 60000 // 60 segundos
-    }
-    // Adicione mais serviços aqui se necessário
-];
+    }));
+};
+
+// Configuração dos serviços a monitorar
+const SERVICES = generateServices();
 
 // Estatísticas globais
 let stats = {
@@ -237,7 +251,7 @@ app.listen(PORT, '0.0.0.0', () => {
     // Lista serviços configurados
     SERVICES.forEach(service => {
         if (service.url) {
-            console.log(`• ${service.name}: ${service.url} (${service.interval})`);
+            console.log(`   • ${service.name}: ${service.url} (${service.interval})`);
         }
     });
 });


### PR DESCRIPTION
## 🎯 Objetivo

Implementa suporte para múltiplas URLs na variável de ambiente `BOT_URL`, permitindo que o Keep-Alive Service monitore vários serviços simultaneamente usando uma única instância.

## ✨ O que mudou?

- **Antes**: A variável `BOT_URL` aceitava apenas uma URL
- **Depois**: A variável `BOT_URL` agora aceita múltiplas URLs separadas por vírgula

## 🔧 Como funciona?

O código agora inclui uma função `generateServices()` que:
1. Lê a variável de ambiente `BOT_URL`
2. Divide o conteúdo por vírgulas usando `split(',')`
3. Remove espaços em branco de cada URL com `trim()`
4. Gera dinamicamente um serviço para cada URL fornecida

## 📝 Exemplo de uso

### Uso simples (1 serviço):
```bash
BOT_URL=https://meu-bot.onrender.com/ping
```

### Uso múltiplo (vários serviços):
```bash
BOT_URL=https://bot1.onrender.com/ping,https://bot2.onrender.com/ping,https://bot3.onrender.com/ping
```

Ou com espaços (serão removidos automaticamente):
```bash
BOT_URL=https://bot1.onrender.com/ping, https://bot2.onrender.com/ping, https://bot3.onrender.com/ping
```

## 🚀 Configuração no Render

No painel do Render, configure a variável de ambiente assim:
- **Key**: `BOT_URL`
- **Value**: `https://bot1.onrender.com/ping,https://bot2.onrender.com/ping`

## ✅ Benefícios

- ✨ Configuração simples via variável de ambiente
- 🔄 Não precisa editar código para adicionar/remover serviços
- 📊 Cada serviço é monitorado independentemente com suas próprias estatísticas
- 🎯 Todos os serviços recebem ping a cada 12 minutos automaticamente

## 🔍 Compatibilidade

Totalmente retrocompatível! Se você usar apenas uma URL (sem vírgulas), funciona exatamente como antes.